### PR TITLE
declare sequin dependency with * instead of empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 , "version"         : "0.1.1"
 , "engines"         : {"node": ">=0.6.0"}
 , "main"            : "./lib/csprng"
-, "dependencies"    : {"sequin": ""}
+, "dependencies"    : {"sequin": "*"}
 
 , "repository"      : { "type"  : "git"
                       , "url"   : "git://github.com/jcoglan/node-csprng.git"


### PR DESCRIPTION
 to work around npm shrinkwrap issue (see https://github.com/npm/npm/issues/11493)
