### PR TITLE
Removed require statement for 'crypto'.

### DIFF
--- a/lib/csprng.js
+++ b/lib/csprng.js
@@ -2,8 +2,7 @@ var DEFAULT_BITS  = 128,
     DEFAULT_RADIX = 16,
     DIGITS        = '0123456789abcdefghijklmnopqrstuvwxyz'.split('');
 
-var crypto = require('crypto'),
-    Seq    = require('sequin');
+var Seq = require('sequin');
 
 var rand = function(bits, radix) {
   bits  = bits  || DEFAULT_BITS;


### PR DESCRIPTION
Crypto is now built into node by default. Removing this require statement resolved issues with apps not being able to locate the crypto package. Fixed my issues immediately! Grabbed original source from npm.